### PR TITLE
Read Rbinary from existing `host` list

### DIFF
--- a/base/utils/R/convert.input.R
+++ b/base/utils/R/convert.input.R
@@ -43,7 +43,8 @@
 ##' @param fcn The function to be executed if records of the output file aren't found in the database. (as a string)
 ##' @param con Database connection object
 ##' @param host Named list identifying the machine where conversion should be performed.
-##'   Currently only \code{host$name} is used by \code{convert.input}, but whole list is passed to other functions
+##'   Currently only \code{host$name} and \code{host$Rbinary} are used by \code{convert.input},
+##'    but the whole list is passed to other functions
 ##' @param browndog List of information related to browndog conversion.  NULL if browndog is not to be used for conversion
 ##' @param write Logical: Write new file records to the database?
 ##' @param format.vars Passed on as arguments to \code{fcn}
@@ -55,7 +56,6 @@
 ##' @param forecast Logical: Is the data product a forecast?
 ##' @param ensemble An integer representing the number of ensembles, or FALSE if it data product is not an ensemble.
 ##' @param ensemble_name If convert.input is being called iteratively for each ensemble, ensemble_name contains the identifying name/number for that ensemble.
-##' @param Rbinary command (including path, if needed) to call the R executable on `host`
 ##' @param ... Additional arguments, passed unchanged to \code{fcn}
 ##' @param dbparms list of parameters to use for opening a database connection
 ##'
@@ -89,7 +89,6 @@ convert.input <-
            ensemble = FALSE,
            ensemble_name = NULL,
            dbparms=NULL,
-           Rbinary = "R",
            ...
   ) {
 
@@ -98,8 +97,7 @@ convert.input <-
   PEcAn.logger::logger.debug(paste("Convert.Inputs", fcn, input.id, host$name, outfolder, formatname, 
                      mimetype, site.id, start_date, end_date))
   
-  # TODO see issue #18
-
+  Rbinary <- ifelse(is.null(host$Rbinary),"R",host$Rbinary)
   
   n <- nchar(outfolder)
   if (substr(outfolder, n, n) != "/") {

--- a/base/utils/man/convert.input.Rd
+++ b/base/utils/man/convert.input.Rd
@@ -28,7 +28,6 @@ convert.input(
   ensemble = FALSE,
   ensemble_name = NULL,
   dbparms = NULL,
-  Rbinary = "R",
   ...
 )
 }
@@ -54,7 +53,8 @@ convert.input(
 \item{con}{Database connection object}
 
 \item{host}{Named list identifying the machine where conversion should be performed.
-Currently only \code{host$name} is used by \code{convert.input}, but whole list is passed to other functions}
+Currently only \code{host$name} and \code{host$Rbinary} are used by \code{convert.input},
+but the whole list is passed to other functions}
 
 \item{browndog}{List of information related to browndog conversion.  NULL if browndog is not to be used for conversion}
 
@@ -79,8 +79,6 @@ Currently only \code{host$name} is used by \code{convert.input}, but whole list 
 \item{ensemble_name}{If convert.input is being called iteratively for each ensemble, ensemble_name contains the identifying name/number for that ensemble.}
 
 \item{dbparms}{list of parameters to use for opening a database connection}
-
-\item{Rbinary}{command (including path, if needed) to call the R executable on \code{host}}
 
 \item{...}{Additional arguments, passed unchanged to \code{fcn}}
 }

--- a/modules/data.atmosphere/R/download.raw.met.module.R
+++ b/modules/data.atmosphere/R/download.raw.met.module.R
@@ -91,8 +91,7 @@
       method = input_met$method,
       pattern = met,
       dbparms=dbparms,
-      ensemble = ensemble,
-      Rbinary = "R"
+      ensemble = ensemble
     )
     
   } else if (register$scale == "site") {
@@ -120,8 +119,7 @@
       lon.in = lon.in,
       pattern = met, 
       site_id = site.id,
-      product = input_met$product,
-      Rbinary = "R"
+      product = input_met$product
     )
     
   } else {

--- a/modules/data.atmosphere/R/extract.nc.module.R
+++ b/modules/data.atmosphere/R/extract.nc.module.R
@@ -38,8 +38,7 @@ if (exists(paste0("extract.nc.", met))) fcn <- paste0("extract.nc.", met)
                             newsite = new.site$id, 
                             overwrite = overwrite,
                             exact.dates = FALSE, 
-                            ensemble = register$ensemble %>% as.numeric(),
-                            Rbinary = "R")
+                            ensemble = register$ensemble %>% as.numeric())
   
   PEcAn.logger::logger.info("Finished Extracting Met")
   

--- a/modules/data.atmosphere/R/met2cf.module.R
+++ b/modules/data.atmosphere/R/met2cf.module.R
@@ -35,8 +35,7 @@
                             write = TRUE, 
                             format.vars = format.vars, 
                             overwrite = overwrite,
-                            exact.dates = FALSE,
-                            Rbinary = "R")
+                            exact.dates = FALSE)
     
     input_name <- paste0(met, "_CF_Permute")
     fcn <- "permute.nc"
@@ -51,8 +50,7 @@
                            pkg = pkg, fcn = fcn, con = con, host = host, browndog = NULL,
                            write = TRUE, 
                            overwrite = overwrite,
-                           exact.dates = FALSE,
-                           Rbinary = "R")
+                           exact.dates = FALSE)
     
   } else if (register$scale == "site") {
     input_name <- paste0(met, "_CF_site_", str_ns)
@@ -81,8 +79,7 @@
                           lat = lat, lon = lon, 
                           format.vars = format.vars, 
                           overwrite = overwrite,
-                          exact.dates = FALSE,
-                          Rbinary = "R")
+                          exact.dates = FALSE)
   }
   
   PEcAn.logger::logger.info("Finished change to CF Standards")

--- a/modules/data.atmosphere/R/met2model.module.R
+++ b/modules/data.atmosphere/R/met2model.module.R
@@ -64,8 +64,7 @@
                               forecast = forecast,
                               ensemble = !is.null(register$ensemble) && as.logical(register$ensemble),
                               ensemble_name = ensemble_name,
-                              dbfile.id=ready.id$dbfile.id,
-                              Rbinary = "R")
+                              dbfile.id=ready.id$dbfile.id)
   }
   
   PEcAn.logger::logger.info(paste("Finished Model Specific Conversion", model.id[1]))

--- a/modules/data.atmosphere/R/metgapfill.module.R
+++ b/modules/data.atmosphere/R/metgapfill.module.R
@@ -37,8 +37,7 @@
                             forecast = forecast,
                             pattern = met,
                             ensemble = !is.null(register$ensemble) && as.logical(register$ensemble),
-                            ensemble_name = ensemble_name,
-                            Rbinary = "R")
+                            ensemble_name = ensemble_name)
   
   print(ready.id)
   

--- a/modules/data.atmosphere/inst/scripts/met.workflow.NARR.R
+++ b/modules/data.atmosphere/inst/scripts/met.workflow.NARR.R
@@ -39,7 +39,7 @@ if (cf == TRUE){
   formatname <- 'CF Meteorology'
   mimetype <- 'application/x-netcdf'
   
-  cf.id <- convert.input(input.id,outfolder,formatname,mimetype,site.id,start_date,end_date,pkg,fcn,write,username,con=con,raw.host=raw.host, Rbinary = "R")
+  cf.id <- convert.input(input.id,outfolder,formatname,mimetype,site.id,start_date,end_date,pkg,fcn,write,username,con=con,raw.host=raw.host)
 }
 
 #--------------------------------------------------------------------------------------------------#
@@ -56,7 +56,7 @@ if (cf == TRUE){
 #   mimetype <- 'application/x-netcdf'
 #   
 #   
-#   perm.id <- convert.input(input.id,outfolder,formatname,mimetype,site.id,start_date,end_date,pkg,fcn,write,username,con=con, Rbinary = "R")
+#   perm.id <- convert.input(input.id,outfolder,formatname,mimetype,site.id,start_date,end_date,pkg,fcn,write,username,con=con)
 # }
 
 #--------------------------------------------------------------------------------------------------#
@@ -75,7 +75,7 @@ if (extract == TRUE){
   formatname <- 'CF Meteorology'
   mimetype <- 'application/x-netcdf'
   
-  extract.id <- convert.input(input.id,outfolder,formatname,mimetype,site.id,start_year,end_year,pkg,fcn,write,username,con=con,newsite = newsite,raw.host=raw.host,write=TRUE, Rbinary = "R")
+  extract.id <- convert.input(input.id,outfolder,formatname,mimetype,site.id,start_year,end_year,pkg,fcn,write,username,con=con,newsite = newsite,raw.host=raw.host,write=TRUE)
 }
 
 #--------------------------------------------------------------------------------------------------#
@@ -97,7 +97,7 @@ if(nchar(model) >2){
   write     <- TRUE
   overwrite <- ""
   
-  model.id <- convert.input(input.id,outfolder,mod.formatname,mod.mimetype,newsite,start_year,end_year,pkg,fcn,write,username,con=con,lst=lst,overwrite=overwrite,raw.host=raw.host,write=TRUE, Rbinary = "R")
+  model.id <- convert.input(input.id,outfolder,mod.formatname,mod.mimetype,newsite,start_year,end_year,pkg,fcn,write,username,con=con,lst=lst,overwrite=overwrite,raw.host=raw.host,write=TRUE)
 
 
 }

--- a/modules/data.atmosphere/inst/scripts/met.workflow.gen.R
+++ b/modules/data.atmosphere/inst/scripts/met.workflow.gen.R
@@ -39,7 +39,7 @@ pkg       <- "PEcAn.data.atmosphere"
 fcn       <-  paste0("met2CF.",fcn.data)
 write     <-  TRUE
 
-cf.id <- convert.input(input.id,outfolder,pkg,fcn,write,username,con, Rbinary = "R") # doesn't update existing record
+cf.id <- convert.input(input.id,outfolder,pkg,fcn,write,username,con) # doesn't update existing record
 }
 
 #--------------------------------------------------------------------------------------------------#
@@ -53,7 +53,7 @@ pkg       <- "PEcAn.data.atmosphere"
 fcn       <- "permute.nc"
 write     <-  TRUE
 
-perm.id <- convert.input(input.id,outfolder,pkg,fcn,write,username,con, Rbinary = "R")
+perm.id <- convert.input(input.id,outfolder,pkg,fcn,write,username,con)
 }
 
 
@@ -69,7 +69,7 @@ pkg       <- "PEcAn.data.atmosphere"
 fcn       <- "extract.nc"
 write     <- TRUE
 
-extract.id <- convert.input(input.id,outfolder,pkg,fcn,write,username,con,newsite = newsite, Rbinary = "R")
+extract.id <- convert.input(input.id,outfolder,pkg,fcn,write,username,con,newsite = newsite)
 }
 
 #--------------------------------------------------------------------------------------------------#
@@ -90,7 +90,7 @@ fcn       <- paste0("met2model.",model)
 write     <- TRUE
 overwrite <- ""
 
-model.id <- convert.input(input.id,outfolder,pkg,fcn,write,username,con,lst=lst,overwrite=overwrite, Rbinary = "R")
+model.id <- convert.input(input.id,outfolder,pkg,fcn,write,username,con,lst=lst,overwrite=overwrite)
 }
 
 #--------------------------------------------------------------------------------------------------#

--- a/modules/data.land/R/ens.veg.module.R
+++ b/modules/data.land/R/ens.veg.module.R
@@ -55,8 +55,7 @@ ens_veg_module <- function(getveg.id, dbparms,
                                          in.name = spp.file$file_name,
                                          n.ensemble = n.ensemble,
                                          machine_host = machine_host,
-                                         source = input_veg$source,
-                                         Rbinary = "R")
+                                         source = input_veg$source)
   
   
 

--- a/modules/data.land/R/get_veg_module.R
+++ b/modules/data.land/R/get_veg_module.R
@@ -53,8 +53,7 @@ get_veg_module <- function(input_veg,
                                 new_site = new_site,
                                 gridres = input_veg$gridres, dbparms = dbparms,
                                 machine_host = machine_host, input_veg = input,
-                                source = input_veg$source,
-                                Rbinary = "R")
+                                source = input_veg$source)
   
     
 
@@ -93,8 +92,7 @@ get_veg_module <- function(input_veg,
                                ##   <age>70</age>
                                ##  </metadata>
                                ##
-                               icmeta = input_veg$metadata,
-                               Rbinary = "R")
+                               icmeta = input_veg$metadata)
 
 
     return(getveg.id)

--- a/modules/data.land/R/put_veg_module.R
+++ b/modules/data.land/R/put_veg_module.R
@@ -72,8 +72,7 @@ put_veg_module <- function(getveg.id, dbparms,
                                               pfts = pfts,
                                               source = input_veg$source,
                                               n.ensemble = n.ensemble,
-                                              host.inputargs = host.inputargs,
-                                              Rbinary = "R")
+                                              host.inputargs = host.inputargs)
   
   
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
This is a PR into @Its-Maniaco's fork of PEcAn, which updates the branch that is the subject of #2954. When merged, it will implement the changes we requested there by reverting the addition of a new `Rbinary` parameter and instead reading it from the `host` list that is already passed as an argument to every `convert.input` call.

@Its-Maniaco, I'm sorry again for asking for this design change after you'd already done the work to implement a new parameter, but I hope this patch makes it easy for you to incorporate it and get the bug fixed and the PR merged.
